### PR TITLE
mongo.Collection#find

### DIFF
--- a/humongolus/mongo.py
+++ b/humongolus/mongo.py
@@ -27,5 +27,13 @@ class Collection(collection.Collection):
 
     def find(self, *args, **kwargs):
         self._as_dict = kwargs.pop("as_dict", None)
-        super(Collection, self).find(*args, **kwargs)
+        if not 'slave_okay' in kwargs:
+            kwargs['slave_okay'] = self.slave_okay
+        if not 'read_preference' in kwargs:
+            kwargs['read_preference'] = self.read_preference
+        if not 'tag_sets' in kwargs:
+            kwargs['tag_sets'] = self.tag_sets
+        if not 'secondary_acceptable_latency_ms' in kwargs:
+            kwargs['secondary_acceptable_latency_ms'] = (
+                self.secondary_acceptable_latency_ms)
         return Cursor(self, my_class=self._class, as_dict=self._as_dict, *args, **kwargs)


### PR DESCRIPTION
Update the find method of the Collection subclass to massage the kwargs
with the replicaset arguments such that the returned Cursor respects the
MongoReplicaSetClient settings.
