### PR TITLE
Minor bug-fixes

### DIFF
--- a/humongolus/__init__.py
+++ b/humongolus/__init__.py
@@ -425,7 +425,7 @@ class List(list):
         
 
     def append(self, obj):
-        types = self._type if self._type is list else [self._type]
+        types = self._type if self._type.__class__ is list else [self._type]
         if self._length and len(self) >= self._length: raise Exception("max length: %s exceeded" % self._length)
         if obj.__class__ in types:
             super(List, self).append(obj)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # setup.py ---
 #
 


### PR DESCRIPTION
Mark setup.py as unicode, stop SyntaxError: Non-ASCII character errors.
Bug fix in List that prevented `list' type as being a sub-type of List
