### PR TITLE
make class return attribute type for field attr

### DIFF
--- a/humongolus/__init__.py
+++ b/humongolus/__init__.py
@@ -262,6 +262,8 @@ class Field(object):
         self._error = None
 
     def __get__(self, instance, owner):
+        if not instance:
+            return self.__class__
         me = instance.__dict__.get(self._name)
         if me:
             if callable(me): return me()

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -10,6 +10,7 @@ from pymongo.connection import Connection
 import logging
 import humongolus as orm
 import humongolus.widget as widget
+import humongolus.field as field
 from humongolus.field import FieldException
 
 conn = Connection()
@@ -262,6 +263,14 @@ class Field(unittest.TestCase):
         with self.assertRaises(orm.DocumentException) as cm:
             obj2.save()
             print cm.exception.errors
+
+    def test_class_attr(self):
+        self.assertEqual(self.obj.__class__.name, field.Char)
+        self.assertEqual(self.obj.__class__.human_id, field.AutoIncrement)
+        self.assertEqual(self.obj.__class__.age, field.Integer)
+        self.assertEqual(self.obj.__class__.height, field.Float)
+        self.assertEqual(self.obj.__class__.weight, field.Float)
+        self.assertEqual(self.obj.__class__.genitalia, field.Char)
 
 
     def tearDown(self):


### PR DESCRIPTION
Currently if you try to access a field type of a Document class. It will fail with `TypeError`. But what is idea is if someone can tell what the type of the field is. 